### PR TITLE
refactor(FileUpload): replace catchFile with handleFileUpload

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -13,7 +13,7 @@
         "@mdx-js/react": "^3.1.0",
         "@next/mdx": "^15.0.4",
         "@vercel/analytics": "^1.4.1",
-        "auera-ui": "^0.1.41",
+        "auera-ui": "file:../package/auera-ui-0.1.42.tgz",
         "next": "^15.1.6",
         "next-mdx-remote": "^5.0.0",
         "prism-react-renderer": "^2.4.0",
@@ -5590,9 +5590,9 @@
       }
     },
     "node_modules/auera-ui": {
-      "version": "0.1.41",
-      "resolved": "https://registry.npmjs.org/auera-ui/-/auera-ui-0.1.41.tgz",
-      "integrity": "sha512-4jAe3kQQ7bGEf3o9Gj2i7SEdb9GP3Zqf4/no1R0gycJe62+ERMCnaww+s3N062Z3NXT8thYS43+pEq4rwI0n6Q==",
+      "version": "0.1.42",
+      "resolved": "file:../package/auera-ui-0.1.42.tgz",
+      "integrity": "sha512-ET4VUhOW5vqmZTrYr1Ocy29m5DOcHqbxkodRiTCK7pqXOEId6W+8NfklUsfR/LyZoeRd3AgCoor9bDWW/FJrNw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.8.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "clear": "rmdir /s /q .next && npm run dev",
-    "ui": "npm i ../package/auera-ui-0.1.39.tgz"
+    "ui": "npm i ../package/auera-ui-0.1.42.tgz"
   },
   "overrides": {
     "react": "$react",
@@ -22,7 +22,7 @@
     "@mdx-js/react": "^3.1.0",
     "@next/mdx": "^15.0.4",
     "@vercel/analytics": "^1.4.1",
-    "auera-ui": "^0.1.41",
+    "auera-ui": "file:../package/auera-ui-0.1.42.tgz",
     "next": "^15.1.6",
     "next-mdx-remote": "^5.0.0",
     "prism-react-renderer": "^2.4.0",

--- a/docs/src/components/example/file-upload/receive.tsx
+++ b/docs/src/components/example/file-upload/receive.tsx
@@ -4,10 +4,10 @@ import { useDocState } from "@/hooks/docs";
 import { replaceInCode } from "@/utils/global";
 import {
   Button,
-  catchFile,
   FileUpload,
   FileUploadList,
   FileUploadTrigger,
+  handleFileUpload,
   Stack,
   TabHandle,
   TabPanel,
@@ -20,11 +20,10 @@ import { LuEye } from "react-icons/lu";
 
 const FileUploadDemo = () => {
   const { lang } = useDocState();
-  const handleFile = catchFile({
-    useFile(file) {
-      toast.success("Check your console for the file data");
-      console.log(file);
-    },
+
+  const handleFile = handleFileUpload((file) => {
+    toast.success("Check your console for the file data");
+    console.log(file);
   });
 
   return (
@@ -69,7 +68,7 @@ const code = `import {
   FileUpload,
   FileUploadList,
   FileUploadTrigger,
-  catchFile,
+  handleFileUpload,
   FileData
 } from "auera-ui";
 import { useState } from "react";
@@ -77,14 +76,12 @@ import { useState } from "react";
 export const UploadDemo = () => {
  const [uploadedFile, setUploadedFile] = useState<FileData | null>(null);
 
- const handleFile = catchFile({
-    useFile(file) {
+  const handleFile = handleFileUpload((file) => {
     // \`\ file\` is of type \`\FileData\`
-    // Store the file in state if needed.
-    console.log(file);
+    toast.success("Check your console for the file data");
     setUploadedFile(file);
-    },
- });
+    console.log(file);
+  });
 
  return (
   <FileUpload onFileUpload={handleFile}>

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auera-ui",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "main": "dist/auera-ui.cjs",
   "module": "dist/auera-ui.es.js",
   "types": "dist/index.d.ts",

--- a/package/src/components/File/FileUpload.tsx
+++ b/package/src/components/File/FileUpload.tsx
@@ -4,12 +4,16 @@ import React, { useState } from "react";
 import { getDisplayName } from "@/utils/displayname";
 import { useMode } from "@/hook/use";
 
+export let clearFile: () => void;
+
 const emptyFile = {
   base64: "",
   main: {
     name: "",
     type: "",
     size: 0,
+    lastModified: 0,
+    webkitRelativePath: "",
   },
 };
 
@@ -47,6 +51,11 @@ const FileUpload: React.FC<FileUploadProps> = ({
     setFiles((files) => {
       return files.filter((_, idx) => idx !== index);
     });
+  };
+
+  clearFile = () => {
+    setFiles([]);
+    setFile(emptyFile);
   };
 
   return (

--- a/package/src/types/auera-ui.ts
+++ b/package/src/types/auera-ui.ts
@@ -406,28 +406,27 @@ export interface PasswordProps extends InputProp {
   hideLock?: boolean;
 }
 
-export interface FileUploadProps {
-  children: React.ReactNode;
-  multiple?: boolean;
-  onFileUpload?: (file: FileData) => void;
-  maxFiles?: number;
-  mode?: ModeType;
-}
-
 export type FileContruct = {
   base64: string;
   main: {
     name: string;
     type: string;
     size: number;
+    lastModified: number;
+    webkitRelativePath: string;
   };
 };
 
 export type FileData = FileContruct | FileContruct[];
+export type FileHandler = (file: FileData) => void;
 
-export type CatchFile = {
-  useFile: (file: FileData) => void;
-};
+export interface FileUploadProps {
+  children: React.ReactNode;
+  multiple?: boolean;
+  onFileUpload?: FileHandler;
+  maxFiles?: number;
+  mode?: ModeType;
+}
 
 export interface UploadDropzone {
   accept?: FileType[];

--- a/package/src/utils/fun.ts
+++ b/package/src/utils/fun.ts
@@ -1,4 +1,4 @@
-import { CatchFile } from "../types/auera-ui";
+import { FileHandler } from "../types/auera-ui";
 import { Currency, DataGroup } from "../types/utils";
 
 /**
@@ -174,26 +174,23 @@ export const groupData = <T>({
 };
 
 /**
- * Utility function that handles file extraction from the `onFileUpload` prop in the `FileUpload` component.
- * It processes the uploaded file and returns either a single `FileData` object or an array of `FileData` objects.
+ * Handles file extraction from the `onFileUpload` prop in the `FileUpload` component.
+ * It processes the uploaded file and provides the extracted file data to the given callback.
  *
- * @param {Object} params - The parameter object.
- * @param {Function} params.useFile - A callback function that processes the uploaded file.
- * @returns {CatchFile['useFile']} The processed file data, either a single `FileData` object or an array of `FileData` objects.
+ * @param {Function} callback - A function that receives the uploaded file data.
+ * @returns {FileHandler} A function that processes a single or multiple uploaded files.
  *
  * @example
- * // Define a file handler using catchFile
- * const handleFile = catchFile({
- *   useFile(file) {
- *     // If a single file is uploaded, extract its base64 and main file structure
- *     const mainFile = !Array.isArray(file) ? file.main : null;
- *     const base64File = !Array.isArray(file) ? file.base64 : null;
+ *   // Define a file handler using handleFileUpload
+ * const handleFile = handleFileUpload((file) => {
+ *   // Extract main file and base64 data if a single file is uploaded
+ *   const mainFile = Array.isArray(file) ? null : file.main;
+ *   const base64File = Array.isArray(file) ? null : file.base64;
  *
- *     // If multiple files are uploaded, store them in an array
- *     const fileArray = Array.isArray(file) ? file : [];
+ *   // Store multiple files in an array
+ *   const fileArray = Array.isArray(file) ? file : [];
  *
- *     console.log(mainFile, base64File, fileArray);
- *   },
+ *   console.log(mainFile, base64File, fileArray);
  * });
  *
  * // Pass it as a prop to the FileUpload component
@@ -201,8 +198,9 @@ export const groupData = <T>({
  *   // Other file upload components
  * </FileUpload>
  */
-export const catchFile = ({ useFile }: CatchFile): CatchFile["useFile"] =>
-  useFile;
+
+export const handleFileUpload = (fileHandler: FileHandler): FileHandler =>
+  fileHandler;
 
 export const paginate = <T>(
   data: T[],
@@ -212,4 +210,9 @@ export const paginate = <T>(
   const startIndex = (currentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
   return data.slice(startIndex, endIndex);
+};
+
+export const hasEmptyFields = <T>(arg: T, fields: Array<keyof T>): boolean => {
+  const hasAllFields = fields.every((val) => arg[val]);
+  return !hasAllFields;
 };


### PR DESCRIPTION
- The function name `catchFile` was unclear and did not accurately describe its purpose.
- `handleFileUpload` is more descriptive and aligns with the functionality of processing uploaded files.